### PR TITLE
Fix issue with Escape Key

### DIFF
--- a/CustomKeybinds/Components/KeySelector.cs
+++ b/CustomKeybinds/Components/KeySelector.cs
@@ -17,6 +17,7 @@ namespace CustomKeyBinds.Components
         private static KeySelector _isSelecting;
         private static Component _ignoreClose;
 
+        public static bool canEscape = true;
 
         private OptionsMenuButton _button;
 
@@ -107,6 +108,9 @@ namespace CustomKeyBinds.Components
                 _isSelecting = null;
                 _ignoreClose.gameObject.SetActive(false);
                 backup?.OnMouseOut();
+
+                if (code == KeyCode.Escape)
+                    canEscape = false;
             }
         }
 

--- a/CustomKeybinds/Patches/OptionsMenuPatches.cs
+++ b/CustomKeybinds/Patches/OptionsMenuPatches.cs
@@ -1,5 +1,6 @@
 ﻿using CustomKeyBinds.Components;
 using HarmonyLib;
+using System;
 using UnityEngine;
 
 using OptionsMenuBehaviour = BOMIGDLINBO;
@@ -38,6 +39,14 @@ namespace CustomKeyBinds.Patches
         [HarmonyPatch(typeof(OptionsMenuBehaviour), nameof(OptionsMenuBehaviour.Update))]
         public static class PatchOptionsMenuUpdate
         {
+            public static bool Prefix(OptionsMenuBehaviour __instance)
+            {
+                if (KeySelector.canEscape)
+                    return true;
+                if (Input.GetKeyUp(KeyCode.Escape))
+                    KeySelector.canEscape = true;
+                return false;
+            }
             public static void Postfix()
             {
                 OptionsMenuButton.HudUpdate();


### PR DESCRIPTION
This issue is cause By unity key handler system
Input.getKeyUp is delay compare to getInput
So we need to wait to receive the event on Update function to catch it and re allow escape key to be pressed to exit the window